### PR TITLE
ci(netlify.toml): improve security headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,9 +3,9 @@
   [headers.values]
     X-Frame-Options = "DENY"
     X-XSS-Protection = "1; mode=block"
-    Content-Security-Policy = "form-action https:"
+    Content-Security-Policy = "default-src https:"
     Referrer-Policy = "strict-origin-when-cross-origin"
-    Strict-Transport-Security = "max-age=2592000"
+    X-Content-Type-Options = "nosniff"
     Feature-Policy = '''
     ambient-light-sensor 'none';
     vibrate 'none';


### PR DESCRIPTION
add x-content-type-options and wind back content-security-policy to only insist on https